### PR TITLE
Fix color mismatch with website layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,7 @@ const App: React.FC = () => {
   const canvasRef = React.useRef<HTMLCanvasElement>(null);
 
   return (
-    <div className="flex flex-col h-screen bg-gradient-to-br from-indigo-500 to-purple-700">
+    <div className="flex flex-col h-screen bg-white">
       <div className="p-2 flex gap-2">
         <MicControl />
         <RecordControl canvasRef={canvasRef} />


### PR DESCRIPTION
Change main background color to white to match website layout.

---
<a href="https://cursor.com/background-agent?bcId=bc-3937a259-4496-4891-a668-32e65aa69db9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3937a259-4496-4891-a668-32e65aa69db9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

